### PR TITLE
Bugfix: Missing env overrides default 

### DIFF
--- a/confypy/loaders.py
+++ b/confypy/loaders.py
@@ -43,7 +43,10 @@ def load_python(path):
 def load_env_keys(keys):
     data = {}
     for each in keys:
-        data[each] = os.getenv(each, None)
+        value = os.getenv(each)
+
+        if value:
+            data[each] = value
 
     return data
 

--- a/confypy/loaders.py
+++ b/confypy/loaders.py
@@ -43,11 +43,10 @@ def load_python(path):
 def load_env_keys(keys):
     data = {}
     for each in keys:
-        value = os.getenv(each)
-
-        if value:
-            data[each] = value
-
+        try:
+            data[each] = os.environ[each]
+        except KeyError:
+            pass
     return data
 
 

--- a/tests/test_confypy.py
+++ b/tests/test_confypy.py
@@ -114,3 +114,14 @@ def test_locations_dict_chain():
 
     assert config.data.name == 'Lucy'
     assert config.data.nombre == 'Ollie'
+
+
+def test_missing_env_key_with_defaults():
+    defaults = {'ZAF': 'ducks'}
+
+    config = Config(chain=True, defaults=defaults)
+    config.locations = [
+    Location.from_env_keys(['ZAF']),
+    ]
+
+    assert config.data.ZAF == 'ducks'

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -48,7 +48,4 @@ def test_load_env_keys_fail():
 
     data = loaders.load_env_keys(['QUX', 'ZAP', 'QUUX'])
 
-    assert data != {}
-    assert data['QUX'] == None
-    assert data['ZAP'] == None
-    assert data['QUUX'] == None
+    assert data == {}


### PR DESCRIPTION
When `loaders.py:load_env_keys` attempt to load a key with `os.getenv` fails it sets a default return value of `None`. In ConfigData this causes the `value_for_key` look up to return `None` even if there is a default value defined.

> This is my first attempt at fixing this bug and need your input.

This version of the fix modifies `loaders.py:load_env_keys` function to only return a value if the env key is not `None`

I did not modify `confypy.py` but did confirm that the try, except block does not throw a `KeyError` when the key has a value of `None`.

```
def value_for_key(self, key):
        maps = self.maps
        for each in maps:
            try:
                return each[key]
            except KeyError:
                pass

        raise KeyError(key)
```

I think another version of this fix could leave `loaders.py` untouched and modify this functinon to also throw a `KeyError` if the value is `None`.

I updated the `test_loaders.py:test_load_env_keys_fail()` test.
I added a test: `test_confypy.py:test_missing_env_key_with_defaults`

Thoughts?
